### PR TITLE
Add external documentation field on schemas

### DIFF
--- a/examples/asyncapi.md
+++ b/examples/asyncapi.md
@@ -219,18 +219,7 @@ Name|Type|Format|Allowed|Default|Description
 `jobId`|`string`||||Job Id.
 `userId`|`string`||||User Id.
 `documentName`|`string`||||Document name.<br />**deprecated**
-`priority`|`string`||`low`<br />`medium`<br />`high`||Priority.
-
-#### Examples
-
-```json
-{
-  "jobId": "1",
-  "userId": "2",
-  "documentName": "Document",
-  "priority": "low"
-}
-```
+`priority`|`string`||`low`<br />`medium`<br />`high`||Priority.<br />Print Job Priority Documentation.<br />[https://www.example.com/docs/api/jobs/priority](https://www.example.com/docs/api/jobs/priority)<br />
 
 ### 3.1.2. Headers
 
@@ -257,15 +246,6 @@ Name|Type|Format|Allowed|Default|Description
 ----|----|------|-------|-------|-----------
 `jobId`|`string`||||Job Id.<br />**required**
 `force`|`boolean`|||`false`|Force cancellation.
-
-#### Examples
-
-```json
-{
-  "jobId": "1",
-  "force": true
-}
-```
 
 ### 3.2.2. Headers
 
@@ -309,15 +289,6 @@ Name|Type|Format|Allowed|Default|Description
 ----|----|------|-------|-------|-----------
 `jobId`|`string`||||Job Id.
 `status`|`string`||`created`<br />`started`<br />`finished`<br />`canceled`||Status.
-
-#### Examples
-
-```json
-{
-  "jobId": "1",
-  "status": "started"
-}
-```
 
 # 4. Security
 

--- a/examples/asyncapi.yml
+++ b/examples/asyncapi.yml
@@ -179,14 +179,9 @@ components:
               - low
               - medium
               - high
-      examples:
-        - json: |-
-            {
-              "jobId": "1",
-              "userId": "2",
-              "documentName": "Document",
-              "priority": "low"
-            }
+            externalDocs:
+              description: Print Job Priority Documentation.
+              url: https://www.example.com/docs/api/jobs/priority
       headers:
         type: object
         properties:
@@ -216,12 +211,6 @@ components:
             default: false
         required:
           - jobId
-      examples:
-        - json: |-
-            {
-              "jobId": "1",
-              "force": true
-            }
       headers:
         type: object
         properties:
@@ -263,12 +252,6 @@ components:
               - started
               - finished
               - canceled
-      examples:
-        - json: |-
-            {
-              "jobId": "1",
-              "status": "started"
-            }
 
   securitySchemes:
 

--- a/filters/proxy.js
+++ b/filters/proxy.js
@@ -66,6 +66,7 @@ filters.proxy = (object) => {
       default: () => object.default,
       deprecated: () => object.deprecated,
       discriminator: () => object.discriminator,
+      externalDocs: () => object.externalDocs,
       readOnly: () => object.readOnly,
       writeOnly: () => object.writeOnly,
       examples: () => object.examples,

--- a/partials/asyncapi/channel.njk
+++ b/partials/asyncapi/channel.njk
@@ -26,7 +26,7 @@
 ### {{ "Parameters" | headings(3) }}
 
 {{ parametersChannelTemplate(channel.parameters()) -}}
-{% elif subsection === "bindings" and channel.bindings() -%}
+{% elif subsection === "bindings" and channel.bindings() | length -%}
 ### {{ "Bindings" | headings(3) }}
 
 {{ channelBindingsTemplate(channel.bindings()) -}}
@@ -112,7 +112,7 @@ Operation|Message|Description
 
 {% endif -%}
 {% for subsection in subsections | chunks -%}
-{% if subsection === "operation.bindings" and operation.bindings() -%}
+{% if subsection === "operation.bindings" and operation.bindings() | length -%}
 #### {{ "Bindings" | headings(4) }}
 
 {{ operationBindingsTemplate(operation.bindings()) -}}

--- a/partials/asyncapi/message.njk
+++ b/partials/asyncapi/message.njk
@@ -45,7 +45,7 @@
 ### {{ "Correlation ID" | headings(3) }}
 
 {{ correlationIdMessageTemplate(message.correlationId()) -}}
-{% elif subsection === "bindings" and message.bindings() -%}
+{% elif subsection === "bindings" and message.bindings() | length -%}
 ### {{ "Bindings" | headings(3) }}
 
 {{ messageBindingsTemplate(message.bindings()) -}}

--- a/partials/asyncapi/schema.njk
+++ b/partials/asyncapi/schema.njk
@@ -136,6 +136,7 @@ Name|Type|Format|Allowed|Default|Description
 {% if field.writeOnly() === true -%} {{- linefeed() -}} Write only: {{ field.writeOnly() | code }} {%- endif -%}
 {% if required -%} {{- linefeed() -}} {{ "required" | bold }} {%- endif -%}
 {% if field.deprecated() -%} {{- linefeed() -}} {{ "deprecated" | bold }} {%- endif -%}
+{% if field.externalDocs() -%} {%- if field.externalDocs().description() | isDefined -%} {{- linefeed() -}} {{ field.externalDocs().description() | safe }} {%- endif -%} {% if field.externalDocs().url() | isDefined -%} {{- linefeed() -}} {{ field.externalDocs().url() | link }} {{- linefeed() -}} {%- endif -%} {%- endif -%}
 {% endmacro -%}
 
 {% macro examplesTemplate(examples) -%}

--- a/partials/asyncapi/server.njk
+++ b/partials/asyncapi/server.njk
@@ -34,7 +34,7 @@ Protocol|{{ protocolNameTemplate(server.protocol()) | code }} {%- if server.prot
 ### {{ "Security" | headings(3) }}
 
 {{ securityServerTemplate(server.security()) -}}
-{% elif subsection === "bindings" and server.bindings() -%}
+{% elif subsection === "bindings" and server.bindings() | length -%}
 ### {{ "Bindings" | headings(3) }}
 
 {{ serverBindingsTemplate(server.bindings()) -}}

--- a/test/filters/proxy.test.js
+++ b/test/filters/proxy.test.js
@@ -55,9 +55,10 @@ test('proxy object', t => {
     'title': '40',
     'default': '41',
     'deprecated': false,
+    'externalDocs': { 'description': '42', 'url': '43' },
     'readOnly': false,
     'writeOnly': true,
-    'examples': ['42'],
+    'examples': ['44'],
   };
 
   const schema = filters.proxy(object);
@@ -104,6 +105,7 @@ test('proxy object', t => {
   t.is(schema.default(), object.default);
   t.is(schema.deprecated(), object.deprecated);
   t.is(schema.discriminator(), object.discriminator);
+  t.is(schema.externalDocs(), object.externalDocs);
   t.is(schema.readOnly(), object.readOnly);
   t.is(schema.writeOnly(), object.writeOnly);
   t.is(schema.examples(), object.examples);


### PR DESCRIPTION
Note: The latest asyncapi-generator has some breaking changes, the bindings attribute returns an empty list instead of a null, and the examples attribute is not working, I fixed all them in this pull request.

Solves #8 